### PR TITLE
ci: upgrade CI dependencies and versions

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -11,5 +11,16 @@ version_files = [
 
 [tool.commitizen.customize]
 schema_pattern = "(break|build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump|deps)(\\(\\S+\\))?!?:(\\s.*)"
-bump_pattern = "^(break|build|feat|fix|refactor|style|test|revert|deps|docs|ci)"
-bump_map = {"break" = "MAJOR", "build" = "MINOR", "feat" = "MINOR", "revert" = "MINOR", "fix" = "PATCH", "refactor" = "PATCH", "style" = "PATCH", "test" = "PATCH", "deps" = "PATCH", "ci" = "PATCH", "docs" = "PATCH"}
+bump_pattern = "^(break|build|feat|fix|refactor|style|test|revert|deps|chore)"
+
+[tool.commitizen.customize.bump_map]
+break = "MAJOR"
+build = "MINOR"
+feat = "MINOR"
+revert = "MINOR"
+fix = "PATCH"
+refactor = "PATCH"
+style = "PATCH"
+test = "PATCH"
+deps = "PATCH"
+chore = "PATCH"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm install
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v4.7.1
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.11
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   bump_version:
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    if: "!startsWith(github.event.head_commit.message, 'bump') && !startsWith(github.event.head_commit.message, 'ci')"
     runs-on: ubuntu-latest
     name: "Bump version"
     outputs:
@@ -25,7 +25,7 @@ jobs:
           ref: "main"
 
       - name: Set up Python
-        uses: actions/setup-python@v4.7.1
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: 3.11
 
@@ -71,7 +71,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
## Description

CI dependencies was updates

## Task Context

### What is the current behavior?

- setup-python action version 4.7.1
- setup-node action installs Node 18
- relese bump_version job executes on ci changes
- .cz.toml mark ci changes as bumpable

### What is the new behavior?

- setup-python action version 5.0.0
- setup-node action installs Node 20
- relese bump_version job do not executes on ci changes
- .cz.toml remove ci changes as bumpable

### Additional Context

<!-- Add here any additional context you think is important. -->

## Checklist

### Test Preview

