### PR TITLE
chore: use gh token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Create Release
         env:
-          GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create ${{ needs.bump_version.outputs.version }} \
             --title ${{ needs.bump_version.outputs.version }} \


### PR DESCRIPTION
## Description

Se cambia ACCESS_TOKEN por GITHUB_TOKEN para corregir errores de rate limit al generear el release:

```
HTTP 403: API rate limit exceeded for user ID 94131130. 
If you reach out to GitHub Support for help, please include the request ID 8018:1BA11C:6E6041:1EFDD85:69721FBF and timestamp 2026-01-22 13:01:51 UTC. 
For more on scraping GitHub and how it may affect your rights, please review our Terms of Service (https://docs.github.com/en/site-policy/github-terms/github-terms-of-service) (https://api.github.com/repos/Drafteame/serverless-plugin-s3-remover/releases)
```

## Task Context

### What is the current behavior?

<!-- current functionality without PR -->

### What is the new behavior?

<!-- expected functionality with PR -->

### Additional Context

<!-- Add here any additional context you think is important. -->

## Checklist

### Test Preview

